### PR TITLE
Add a test for verifyToken

### DIFF
--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updates README to demonstrate `verify` rather than `verifyToken`, and to note
   that the test mixin applies to fakes as well as mocks.
+* Add an additional test for `verifyToken`.
 
 ## 2.1.1
 

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -63,6 +63,20 @@ class ImplementsVerifyTokenPluginPlatformUsingMockPlatformInterfaceMixin
 
 class ExtendsVerifyTokenPluginPlatform extends VerifyTokenPluginPlatform {}
 
+class ConstVerifyTokenPluginPlatform extends PlatformInterface {
+  ConstVerifyTokenPluginPlatform() : super(token: _token);
+
+  static const Object _token = Object(); // invalid
+
+  static set instance(ConstVerifyTokenPluginPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+  }
+}
+
+class ImplementsConstVerifyTokenPluginPlatform extends PlatformInterface implements ConstVerifyTokenPluginPlatform {
+  ImplementsConstVerifyTokenPluginPlatform(): super(token: const Object());
+}
+
 void main() {
   group('`verify`', () {
     test('prevents implementation with `implements`', () {
@@ -111,6 +125,10 @@ void main() {
 
     test('allows extending', () {
       VerifyTokenPluginPlatform.instance = ExtendsVerifyTokenPluginPlatform();
+    });
+
+    test('does not prevent `const Object()` token', () {
+      ConstVerifyTokenPluginPlatform.instance = ImplementsConstVerifyTokenPluginPlatform();
     });
   });
 }


### PR DESCRIPTION
Optional but maybe helpful test that ensures that `verifyToken` doesn't throw an assertion when `const Token()` is used.

If you think this is more confusing than it's worth, just close the PR.